### PR TITLE
Add Google OAuth and role support

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -16,6 +16,14 @@ nav a:hover {
   text-decoration: underline;
 }
 
+.header {
+  display: flex;
+  justify-content: space-between;
+  background-color: #eee;
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+}
+
 @media (max-width: 600px) {
   nav {
     flex-direction: column;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,11 +3,20 @@ import ClientList from './components/ClientList';
 import AddClient from './components/AddClient';
 import ClientDetails from './components/ClientDetails';
 import Report from './components/Report';
+import { AuthProvider, useAuth } from './AuthProvider';
+import Login from './Login';
 import './App.css';
 
-export default function App() {
+function MainRoutes() {
+  const { user, role, logout } = useAuth();
+  if (!user) return <Login />;
+
   return (
-    <Router>
+    <>
+      <header className="header">
+        <span>{user.displayName} - {role}</span>
+        <button onClick={logout}>Cerrar sesión</button>
+      </header>
       <nav>
         <Link to="/">Clientes</Link>
         <Link to="/add">Nuevo cliente</Link>
@@ -21,6 +30,16 @@ export default function App() {
           <Route path="/report" element={<Report />} />
         </Routes>
       </div>
-    </Router>
+    </>
+  );
+}
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <Router>
+        <MainRoutes />
+      </Router>
+    </AuthProvider>
   );
 }

--- a/frontend/src/AuthProvider.jsx
+++ b/frontend/src/AuthProvider.jsx
@@ -1,0 +1,43 @@
+/* eslint react-refresh/only-export-components: off */
+import { createContext, useContext, useEffect, useState } from 'react'
+import { signInWithPopup, signOut, onAuthStateChanged } from 'firebase/auth'
+import { auth, googleProvider, db } from './firebase'
+import { doc, getDoc, setDoc } from 'firebase/firestore'
+
+const AuthContext = createContext(null)
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null)
+  const [role, setRole] = useState(null)
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, async u => {
+      if (u) {
+        setUser(u)
+        const ref = doc(db, 'users', u.uid)
+        const snap = await getDoc(ref)
+        if (snap.exists()) {
+          setRole(snap.data().role)
+        } else {
+          await setDoc(ref, { role: 'Vendedor' })
+          setRole('Vendedor')
+        }
+      } else {
+        setUser(null)
+        setRole(null)
+      }
+    })
+    return unsub
+  }, [])
+
+  const login = () => signInWithPopup(auth, googleProvider)
+  const logout = () => signOut(auth)
+
+  return (
+    <AuthContext.Provider value={{ user, role, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => useContext(AuthContext)

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,0 +1,11 @@
+import { useAuth } from './AuthProvider'
+
+export default function Login() {
+  const { login } = useAuth()
+  return (
+    <div className="container">
+      <h2>Ingresa</h2>
+      <button onClick={login}>Iniciar sesión con Google</button>
+    </div>
+  )
+}

--- a/frontend/src/firebase.js
+++ b/frontend/src/firebase.js
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
+import { getAuth, GoogleAuthProvider } from 'firebase/auth';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -12,3 +13,5 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
+export const auth = getAuth(app);
+export const googleProvider = new GoogleAuthProvider();


### PR DESCRIPTION
## Summary
- integrate Firebase Auth with Google provider
- create AuthProvider context for login/logout and role fetch
- show login screen when not signed in
- display role in header and allow signout
- basic header styles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887a29f421c8325bed9ca7fbc753b31