### PR TITLE
Add sales feature and role guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ La carpeta [`frontend/`](frontend/) incluye el código de la aplicación; el con
 
 Para generar la versión estática utilizada en producción ejecute `npm run build` y copie los archivos de la carpeta `dist` en la raíz del proyecto.
 
+## Roles de usuario
+
+La aplicación maneja permisos básicos mediante un campo `role` guardado en la colección `users` de Firestore. Al iniciar sesión por primera vez se asigna automáticamente el rol **Vendedor**. Para cambiarlo debe editarse dicho documento desde la consola de Firebase y establecer el valor deseado, por ejemplo **Administrador**.
+
+Actualmente el rol sólo se muestra en la interfaz, pero permite distinguir qué usuario realizó cada operación si se consulta la base de datos.
+
 ## Licencia
 
 Este proyecto se distribuye bajo los términos de la licencia MIT. Consulte el archivo [LICENSE](LICENSE) para más información.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import ClientList from './components/ClientList';
 import AddClient from './components/AddClient';
 import ClientDetails from './components/ClientDetails';
 import Report from './components/Report';
+import AddSale from './components/AddSale';
 import { AuthProvider, useAuth } from './AuthProvider';
 import Login from './Login';
 import './App.css';
@@ -21,6 +22,7 @@ function MainRoutes() {
         <Link to="/">Clientes</Link>
         <Link to="/add">Nuevo cliente</Link>
         <Link to="/report">Reporte</Link>
+        <Link to="/sale">Nueva venta</Link>
       </nav>
       <div className="container">
         <Routes>
@@ -28,6 +30,7 @@ function MainRoutes() {
           <Route path="/add" element={<AddClient />} />
           <Route path="/client/:id" element={<ClientDetails />} />
           <Route path="/report" element={<Report />} />
+          <Route path="/sale" element={<AddSale />} />
         </Routes>
       </div>
     </>

--- a/frontend/src/components/AddSale.jsx
+++ b/frontend/src/components/AddSale.jsx
@@ -1,0 +1,50 @@
+import { collection, getDocs, doc, addDoc, updateDoc, increment } from 'firebase/firestore';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { db } from '../firebase';
+
+export default function AddSale() {
+  const [clients, setClients] = useState([]);
+  const [clientId, setClientId] = useState('');
+  const [amount, setAmount] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const load = async () => {
+      const snap = await getDocs(collection(db, 'clients'));
+      setClients(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+    };
+    load();
+  }, []);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    if (!clientId || !amount) return;
+    const value = parseFloat(amount);
+    const ref = doc(db, 'clients', clientId);
+    await addDoc(collection(ref, 'sales'), { amount: value, date: Date.now() });
+    await updateDoc(ref, { balance: increment(value), total: increment(value) });
+    navigate(`/client/${clientId}`);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Nueva Venta</h2>
+      <select value={clientId} onChange={e => setClientId(e.target.value)} required>
+        <option value="" disabled>Selecciona un cliente</option>
+        {clients.map(c => (
+          <option key={c.id} value={c.id}>{c.name}</option>
+        ))}
+      </select>
+      <input
+        value={amount}
+        onChange={e => setAmount(e.target.value)}
+        placeholder="Monto"
+        type="number"
+        step="0.01"
+        required
+      />
+      <button type="submit">Registrar venta</button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add AddSale component
- show sales and payments history
- update client balance on payments
- add link and route for sales in App
- document user roles in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887d0b39b6083258fb1aa28ca066624