### PR TITLE
Add payment editing and login restrictions

### DIFF
--- a/frontend/src/AuthProvider.jsx
+++ b/frontend/src/AuthProvider.jsx
@@ -13,6 +13,13 @@ export function AuthProvider({ children }) {
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, async u => {
       if (u) {
+        const allowSnap = await getDoc(doc(db, 'usuarios', u.email))
+        if (!allowSnap.exists()) {
+          await signOut(auth)
+          setUser(null)
+          setRole(null)
+          return
+        }
         setUser(u)
         const ref = doc(db, 'users', u.uid)
         const snap = await getDoc(ref)


### PR DESCRIPTION
## Summary
- restrict sign-in to emails present in `usuarios` collection
- enable editing and deleting of payment history

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6887d384356c8325b49a73e402a03f91