### PR TITLE
Add account statement modal and PDF ticket

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "firebase": "^12.0.0",
+        "html2canvas": "^1.4.1",
+        "jspdf": "^3.0.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -270,6 +272,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2079,6 +2090,13 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
@@ -2098,6 +2116,13 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2191,12 +2216,33 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -2242,6 +2288,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2272,6 +2330,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2336,6 +2414,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.44.0.tgz",
+      "integrity": "sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2349,6 +2439,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -2382,6 +2481,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.191",
@@ -2686,6 +2795,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2843,6 +2958,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -2996,6 +3124,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
+      "integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/keyv": {
@@ -3203,6 +3349,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3296,6 +3449,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
@@ -3327,6 +3490,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3344,6 +3514,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -3455,6 +3635,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -3505,6 +3695,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tinyglobby": {
@@ -3588,6 +3797,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "firebase": "^12.0.0",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^3.0.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -116,3 +116,18 @@ form {
   font-size: 1.2rem;
   cursor: pointer;
 }
+
+.actions {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.actions button,
+.actions a {
+  background: none;
+  border: none;
+  padding: 0.25rem;
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+}

--- a/frontend/src/components/AccountStatement.jsx
+++ b/frontend/src/components/AccountStatement.jsx
@@ -1,0 +1,68 @@
+import { collection, getDoc, getDocs, doc } from 'firebase/firestore';
+import { useEffect, useState, useRef } from 'react';
+import { db } from '../firebase';
+import jsPDF from 'jspdf';
+import html2canvas from 'html2canvas';
+
+export default function AccountStatement({ clientId }) {
+  const [client, setClient] = useState(null);
+  const [sales, setSales] = useState([]);
+  const [payments, setPayments] = useState([]);
+  const contentRef = useRef(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const cSnap = await getDoc(doc(db, 'clients', clientId));
+      if (!cSnap.exists()) return;
+      setClient({ id: cSnap.id, ...cSnap.data() });
+      const salesSnap = await getDocs(collection(db, 'clients', clientId, 'sales'));
+      setSales(salesSnap.docs.map(d => ({ id: d.id, ...d.data() })));
+      const paySnap = await getDocs(collection(db, 'clients', clientId, 'payments'));
+      setPayments(paySnap.docs.map(d => ({ id: d.id, ...d.data() })));
+    };
+    load();
+  }, [clientId]);
+
+  const exportPdf = async () => {
+    const canvas = await html2canvas(contentRef.current);
+    const imgData = canvas.toDataURL('image/png');
+    const pdf = new jsPDF();
+    const imgProps = pdf.getImageProperties(imgData);
+    const pdfWidth = pdf.internal.pageSize.getWidth();
+    const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+    pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
+    pdf.save(`estado-${client.name}.pdf`);
+  };
+
+  if (!client) return <p>Cargando...</p>;
+
+  const totalSales = sales.reduce((sum, s) => sum + s.amount, 0);
+  const totalPayments = payments.reduce((sum, p) => sum + p.amount, 0);
+
+  return (
+    <div>
+      <div ref={contentRef}>
+        <h2>Estado de cuenta</h2>
+        <p><strong>Nombre:</strong> {client.name}</p>
+        <p><strong>Teléfono:</strong> {client.phone}</p>
+        {client.notes && <p><strong>Notas:</strong> {client.notes}</p>}
+        <p><strong>Saldo actual:</strong> ${client.balance || 0}</p>
+        <h3>Ventas</h3>
+        <ul>
+          {sales.map(s => (
+            <li key={s.id}>{new Date(s.date).toLocaleDateString()} - {s.description} - ${s.amount}</li>
+          ))}
+        </ul>
+        <h3>Abonos</h3>
+        <ul>
+          {payments.map(p => (
+            <li key={p.id}>{new Date(p.date).toLocaleDateString()} - ${p.amount}</li>
+          ))}
+        </ul>
+        <p><strong>Total compras:</strong> ${totalSales}</p>
+        <p><strong>Total abonos:</strong> ${totalPayments}</p>
+      </div>
+      <button onClick={exportPdf}>Generar PDF</button>
+    </div>
+  );
+}

--- a/frontend/src/components/AddSale.jsx
+++ b/frontend/src/components/AddSale.jsx
@@ -1,5 +1,6 @@
 import { collection, getDocs, doc, addDoc, updateDoc, increment } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
+import jsPDF from 'jspdf';
 import { db } from '../firebase';
 
 export default function AddSale({ go, onDone }) {
@@ -21,8 +22,21 @@ export default function AddSale({ go, onDone }) {
     if (!clientId || !amount || !desc) return;
     const value = parseFloat(amount);
     const ref = doc(db, 'clients', clientId);
-    await addDoc(collection(ref, 'sales'), { amount: value, description: desc, date: Date.now() });
+    const date = Date.now();
+    await addDoc(collection(ref, 'sales'), { amount: value, description: desc, date });
     await updateDoc(ref, { balance: increment(value), total: increment(value) });
+
+    const client = clients.find(c => c.id === clientId);
+    if (client) {
+      const pdf = new jsPDF({ unit: 'mm', format: [58, 100] });
+      pdf.setFontSize(12);
+      pdf.text('Ticket de Venta', 5, 10);
+      pdf.text(`Cliente: ${client.name}`, 5, 20);
+      pdf.text(`Fecha: ${new Date(date).toLocaleString()}`, 5, 30);
+      pdf.text(desc, 5, 40);
+      pdf.text(`Monto: $${value.toFixed(2)}`, 5, 50);
+      pdf.save('ticket.pdf');
+    }
     if (onDone) onDone(clientId);
     else go('client', clientId);
   };

--- a/frontend/src/components/ClientList.jsx
+++ b/frontend/src/components/ClientList.jsx
@@ -3,12 +3,14 @@ import { useEffect, useState } from 'react';
 import { db } from '../firebase';
 import AddClient from './AddClient';
 import Modal from './Modal';
+import AccountStatement from './AccountStatement';
 
 export default function ClientList({ go }) {
   const [clients, setClients] = useState([]);
   const [search, setSearch] = useState('');
   const [show, setShow] = useState(false);
   const [editClient, setEditClient] = useState(null);
+  const [statementId, setStatementId] = useState(null);
 
   const fetchClients = async () => {
     const snapshot = await getDocs(collection(db, 'clients'));
@@ -36,17 +38,23 @@ export default function ClientList({ go }) {
         onChange={e => setSearch(e.target.value)}
       />
       <ul className="list">
-        {filtered.map(c => (
-          <li key={c.id}>
-            <span>
-              <button onClick={() => go('client', c.id)}>{c.name}</button> - deuda: ${c.balance || 0}
-            </span>
-            <span>
-              <button onClick={() => setEditClient(c)}>✏️</button>
-              <button onClick={() => removeClient(c)}>🗑️</button>
-            </span>
-          </li>
-        ))}
+        {filtered.map(c => {
+          const cleanPhone = (c.phone || '').replace(/\D/g, '');
+          return (
+            <li key={c.id}>
+              <span className="name">{c.name} - deuda: ${c.balance || 0}</span>
+              <span className="actions">
+                <button onClick={() => go('client', c.id)}>👁️</button>
+                <button onClick={() => setStatementId(c.id)}>📄</button>
+                {cleanPhone && (
+                  <a href={`https://wa.me/${cleanPhone}`} target="_blank" rel="noopener noreferrer">💬</a>
+                )}
+                <button onClick={() => setEditClient(c)}>✏️</button>
+                <button onClick={() => removeClient(c)}>🗑️</button>
+              </span>
+            </li>
+          );
+        })}
       </ul>
       {show && (
         <Modal onClose={() => setShow(false)}>
@@ -56,6 +64,11 @@ export default function ClientList({ go }) {
       {editClient && (
         <Modal onClose={() => setEditClient(null)}>
           <AddClient client={editClient} onDone={() => { setEditClient(null); fetchClients(); }} />
+        </Modal>
+      )}
+      {statementId && (
+        <Modal onClose={() => setStatementId(null)}>
+          <AccountStatement clientId={statementId} />
         </Modal>
       )}
     </div>


### PR DESCRIPTION
## Summary
- implement new `AccountStatement` component to show client info and download as PDF
- update `ClientList` with action bar icons, WhatsApp link and statement modal
- generate sale ticket PDF when a sale is created
- style action bar
- add `jspdf` and `html2canvas` dependencies

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68881f78b2688325bf4f2a572aeda5c1