### PR TITLE
Modernize credit sales UI with Tailwind

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sistema de Ventas a Crédito</title>
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,9 +12,13 @@ import './App.css'
 
 function MainContent({ page, setPage }) {
   const { user, role, logout } = useAuth()
+  const [open, setOpen] = useState(false)
   if (!user) return <Login />
 
-  const go = (name, clientId = null) => setPage({ name, clientId })
+  const go = (name, clientId = null) => {
+    setPage({ name, clientId })
+    setOpen(false)
+  }
 
   let content
   switch (page.name) {
@@ -35,34 +39,38 @@ function MainContent({ page, setPage }) {
   }
 
   return (
-    <>
-      <header className="header">
-        <div className="user-info">
-          <img src={user.photoURL} alt="avatar" />
-          <div>
-            <strong>{user.displayName}</strong>
-            <div className="role">{role}</div>
+    <div className="flex min-h-screen bg-gray-100">
+      <aside className={`bg-slate-800 text-white w-60 p-4 space-y-2 fixed inset-y-0 left-0 transform ${open ? 'translate-x-0' : '-translate-x-full'} transition-transform md:relative md:translate-x-0`}>
+        <h1 className="text-lg font-semibold mb-4">Menú</h1>
+        <nav className="flex flex-col gap-2">
+          <button onClick={() => go('sales')} className="flex items-center gap-2 px-3 py-2 rounded hover:bg-slate-700 text-left">
+            <img src={cart} alt="" className="w-5 h-5" />Ventas
+          </button>
+          <button onClick={() => go('clients')} className="flex items-center gap-2 px-3 py-2 rounded hover:bg-slate-700 text-left">
+            <img src={users} alt="" className="w-5 h-5" />Clientes
+          </button>
+          <button onClick={() => go('finance')} className="flex items-center gap-2 px-3 py-2 rounded hover:bg-slate-700 text-left">
+            <img src={dollar} alt="" className="w-5 h-5" />Finanzas
+          </button>
+        </nav>
+      </aside>
+      <div className="flex-1 flex flex-col md:ml-60">
+        <header className="flex items-center justify-between bg-white shadow px-4 py-2 fixed w-full md:relative md:ml-60">
+          <button className="md:hidden" onClick={() => setOpen(!open)}>
+            ☰
+          </button>
+          <div className="flex items-center gap-2">
+            <img src={user.photoURL} alt="avatar" className="w-8 h-8 rounded-full" />
+            <div>
+              <p className="font-semibold leading-none">{user.displayName}</p>
+              <p className="text-xs text-gray-500">{role}</p>
+            </div>
           </div>
-        </div>
-        <button onClick={logout}>Cerrar sesión</button>
-      </header>
-      <nav>
-        <button onClick={() => go('sales')}>
-          <img src={cart} alt="" className="icon" />Ventas
-        </button>
-        <span className="sep">|</span>
-        <button onClick={() => go('clients')}>
-          <img src={users} alt="" className="icon" />Clientes
-        </button>
-        <span className="sep">|</span>
-        <button onClick={() => go('finance')}>
-          <img src={dollar} alt="" className="icon" />Finanzas
-        </button>
-      </nav>
-      <div className="container">
-        {content}
+          <button onClick={logout} className="bg-red-500 text-white px-3 py-1 rounded">Cerrar sesión</button>
+        </header>
+        <main className="p-4 mt-12 md:mt-4 flex-1">{content}</main>
       </div>
-    </>
+    </div>
   )
 }
 

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -3,10 +3,10 @@ import { useAuth } from './AuthProvider'
 export default function Login() {
   const { login } = useAuth()
   return (
-    <div className="login-wrapper">
-      <div className="login-box">
-        <h2>Ingresa</h2>
-        <button onClick={login}>Iniciar sesión con Google</button>
+    <div className="flex items-center justify-center h-screen bg-slate-100">
+      <div className="bg-white p-6 rounded shadow text-center space-y-4">
+        <h2 className="text-xl font-semibold">Ingresa</h2>
+        <button onClick={login} className="bg-blue-600 text-white px-4 py-2 rounded">Iniciar sesión con Google</button>
       </div>
     </div>
   )

--- a/frontend/src/components/AccountStatement.jsx
+++ b/frontend/src/components/AccountStatement.jsx
@@ -40,21 +40,21 @@ export default function AccountStatement({ clientId }) {
   const totalPayments = payments.reduce((sum, p) => sum + p.amount, 0);
 
   return (
-    <div>
-      <div ref={contentRef}>
-        <h2>Estado de cuenta</h2>
+    <div className="space-y-4">
+      <div ref={contentRef} className="space-y-2">
+        <h2 className="text-lg font-semibold">Estado de cuenta</h2>
         <p><strong>Nombre:</strong> {client.name}</p>
         <p><strong>Teléfono:</strong> {client.phone}</p>
         {client.notes && <p><strong>Notas:</strong> {client.notes}</p>}
         <p><strong>Saldo actual:</strong> ${client.balance || 0}</p>
-        <h3>Ventas</h3>
-        <ul>
+        <h3 className="font-semibold">Ventas</h3>
+        <ul className="list-disc pl-5">
           {sales.map(s => (
             <li key={s.id}>{new Date(s.date).toLocaleDateString()} - {s.description} - ${s.amount}</li>
           ))}
         </ul>
-        <h3>Abonos</h3>
-        <ul>
+        <h3 className="font-semibold">Abonos</h3>
+        <ul className="list-disc pl-5">
           {payments.map(p => (
             <li key={p.id}>{new Date(p.date).toLocaleDateString()} - ${p.amount}</li>
           ))}
@@ -62,7 +62,7 @@ export default function AccountStatement({ clientId }) {
         <p><strong>Total compras:</strong> ${totalSales}</p>
         <p><strong>Total abonos:</strong> ${totalPayments}</p>
       </div>
-      <button onClick={exportPdf}>Generar PDF</button>
+      <button onClick={exportPdf} className="bg-blue-600 text-white px-3 py-2 rounded">Generar PDF</button>
     </div>
   );
 }

--- a/frontend/src/components/AddClient.jsx
+++ b/frontend/src/components/AddClient.jsx
@@ -36,26 +36,29 @@ export default function AddClient({ go, onDone, client }) {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <h2>{client ? 'Editar Cliente' : 'Nuevo Cliente'}</h2>
+    <form onSubmit={handleSubmit} className="bg-white p-4 rounded shadow max-w-md mx-auto space-y-4">
+      <h2 className="text-lg font-semibold text-center">{client ? 'Editar Cliente' : 'Nuevo Cliente'}</h2>
       <input
+        className="w-full border rounded px-3 py-2"
         value={name}
         onChange={e => setName(e.target.value)}
         placeholder="Nombre"
         required
       />
       <input
+        className="w-full border rounded px-3 py-2"
         value={phone}
         onChange={e => setPhone(e.target.value)}
         placeholder="Teléfono"
         pattern="\(\d{3}\) \d{3} \d{4}"
       />
       <input
+        className="w-full border rounded px-3 py-2"
         value={notes}
         onChange={e => setNotes(e.target.value)}
         placeholder="Observaciones"
       />
-      <button type="submit">Guardar</button>
+      <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">Guardar</button>
     </form>
   );
 }

--- a/frontend/src/components/AddSale.jsx
+++ b/frontend/src/components/AddSale.jsx
@@ -42,21 +42,28 @@ export default function AddSale({ go, onDone }) {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <h2>Nueva Venta</h2>
-      <select value={clientId} onChange={e => setClientId(e.target.value)} required>
+    <form onSubmit={handleSubmit} className="bg-white p-4 rounded shadow max-w-md mx-auto space-y-4">
+      <h2 className="text-lg font-semibold text-center">Nueva Venta</h2>
+      <select
+        className="w-full border rounded px-3 py-2"
+        value={clientId}
+        onChange={e => setClientId(e.target.value)}
+        required
+      >
         <option value="" disabled>Selecciona un cliente</option>
         {clients.map(c => (
           <option key={c.id} value={c.id}>{c.name}</option>
         ))}
       </select>
       <input
+        className="w-full border rounded px-3 py-2"
         value={desc}
         onChange={e => setDesc(e.target.value)}
-        placeholder="Descripci\u00f3n"
+        placeholder="Descripción"
         required
       />
       <input
+        className="w-full border rounded px-3 py-2"
         value={amount}
         onChange={e => setAmount(e.target.value)}
         placeholder="Monto"
@@ -64,7 +71,7 @@ export default function AddSale({ go, onDone }) {
         step="0.01"
         required
       />
-      <button type="submit">Registrar venta</button>
+      <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">Registrar venta</button>
     </form>
   );
 }

--- a/frontend/src/components/ClientDetails.jsx
+++ b/frontend/src/components/ClientDetails.jsx
@@ -111,9 +111,9 @@ export default function ClientDetails({ id, go }) {
   if (!client) return <p>Cargando...</p>;
 
   return (
-    <div>
-      <button onClick={() => go('list')}>Regresar</button>
-      <h2>
+    <div className="space-y-4">
+      <button onClick={() => go('list')} className="text-blue-600">Regresar</button>
+      <h2 className="text-lg font-semibold flex items-center gap-2">
         {client.name}
         <button onClick={() => setEditMode(true)}>
           <img src={editIcon} alt="editar" className="icon" />
@@ -125,24 +125,25 @@ export default function ClientDetails({ id, go }) {
       <p>Teléfono: {client.phone}</p>
       {client.notes && <p>Observaciones: {client.notes}</p>}
       <p>Deuda actual: ${client.balance || 0}</p>
-      <form onSubmit={addPayment}>
-        <input value={amount} onChange={e => setAmount(e.target.value)} placeholder="Monto del abono" type="number" step="0.01" />
-        <button type="submit">Registrar abono</button>
+      <form onSubmit={addPayment} className="flex gap-2">
+        <input className="border rounded px-3 py-2 flex-1" value={amount} onChange={e => setAmount(e.target.value)} placeholder="Monto del abono" type="number" step="0.01" />
+        <button type="submit" className="bg-blue-600 text-white px-3 py-2 rounded">Registrar abono</button>
       </form>
-      <h3>Ventas</h3>
-      <ul className="list">
+      <h3 className="font-semibold">Ventas</h3>
+      <ul className="grid gap-2">
         {sales.map(s => (
-          <li key={s.id}>
+          <li key={s.id} className="bg-white p-2 rounded shadow">
             {editingSaleId === s.id ? (
               <>
                 <input
+                  className="border rounded px-2 py-1 mr-2"
                   type="number"
                   step="0.01"
                   value={editSaleAmount}
                   onChange={e => setEditSaleAmount(e.target.value)}
                 />
-                <button onClick={() => saveEditSale(s)}>Guardar</button>
-                <button onClick={cancelEditSale}>Cancelar</button>
+                <button onClick={() => saveEditSale(s)} className="bg-blue-600 text-white px-2 py-1 rounded mr-1">Guardar</button>
+                <button onClick={cancelEditSale} className="px-2 py-1 rounded border">Cancelar</button>
               </>
             ) : (
               <>
@@ -158,20 +159,21 @@ export default function ClientDetails({ id, go }) {
           </li>
         ))}
       </ul>
-      <h3>Abonos</h3>
-      <ul className="list">
+      <h3 className="font-semibold">Abonos</h3>
+      <ul className="grid gap-2">
         {payments.map(p => (
-          <li key={p.id}>
+          <li key={p.id} className="bg-white p-2 rounded shadow">
             {editingId === p.id ? (
               <>
                 <input
+                  className="border rounded px-2 py-1 mr-2"
                   type="number"
                   step="0.01"
                   value={editAmount}
                   onChange={e => setEditAmount(e.target.value)}
                 />
-                <button onClick={() => saveEdit(p)}>Guardar</button>
-                <button onClick={cancelEdit}>Cancelar</button>
+                <button onClick={() => saveEdit(p)} className="bg-blue-600 text-white px-2 py-1 rounded mr-1">Guardar</button>
+                <button onClick={cancelEdit} className="px-2 py-1 rounded border">Cancelar</button>
               </>
             ) : (
               <>

--- a/frontend/src/components/ClientList.jsx
+++ b/frontend/src/components/ClientList.jsx
@@ -36,22 +36,25 @@ export default function ClientList({ go }) {
   };
 
   return (
-    <div>
-      <button onClick={() => setShow(true)}>
-        <img src={plus} alt="" className="icon" />Nuevo cliente
-      </button>
-      <input
-        placeholder="Buscar cliente"
-        value={search}
-        onChange={e => setSearch(e.target.value)}
-      />
-      <ul className="list">
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <button onClick={() => setShow(true)} className="flex items-center gap-2 bg-blue-600 text-white px-3 py-2 rounded">
+          <img src={plus} alt="" className="w-5 h-5" />Nuevo cliente
+        </button>
+        <input
+          className="border rounded px-3 py-2"
+          placeholder="Buscar cliente"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+      </div>
+      <ul className="grid gap-3">
         {filtered.map(c => {
           const cleanPhone = (c.phone || '').replace(/\D/g, '');
           return (
-            <li key={c.id}>
-              <span className="name">{c.name} - deuda: ${c.balance || 0}</span>
-              <span className="actions">
+            <li key={c.id} className="bg-white p-4 rounded shadow flex justify-between items-center">
+              <span className="font-medium">{c.name} - deuda: ${c.balance || 0}</span>
+              <span className="flex gap-1">
                 <button onClick={() => go('client', c.id)}>
                   <img src={eye} alt="ver" className="icon" />
                 </button>

--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -1,8 +1,8 @@
 export default function Modal({ children, onClose }) {
   return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()}>
-        <button className="close" onClick={onClose}>×</button>
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center" onClick={onClose}>
+      <div className="bg-white p-4 rounded shadow relative max-w-full" onClick={e => e.stopPropagation()}>
+        <button className="absolute top-1 right-1" onClick={onClose}>×</button>
         {children}
       </div>
     </div>

--- a/frontend/src/components/Report.jsx
+++ b/frontend/src/components/Report.jsx
@@ -73,12 +73,14 @@ export default function Report() {
   };
 
   return (
-    <div>
-      <h2>Finanzas</h2>
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Finanzas</h2>
       <p>Total ventas: ${summary.total}</p>
       <p>Saldo pendiente: ${summary.outstanding}</p>
-      <button onClick={exportDb}>Exportar DB</button>
-      <button onClick={() => fileRef.current.click()}>Importar DB</button>
+      <div className="flex gap-2">
+        <button onClick={exportDb} className="bg-blue-600 text-white px-3 py-1 rounded">Exportar DB</button>
+        <button onClick={() => fileRef.current.click()} className="bg-blue-600 text-white px-3 py-1 rounded">Importar DB</button>
+      </div>
       <input type="file" accept="application/json" ref={fileRef} style={{ display: 'none' }} onChange={importDb} />
     </div>
   );

--- a/frontend/src/components/SalesList.jsx
+++ b/frontend/src/components/SalesList.jsx
@@ -35,18 +35,21 @@ export default function SalesList() {
   );
 
   return (
-    <div>
-      <button onClick={() => setShow(true)}>
-        <img src={plus} alt="" className="icon" />Nueva venta
-      </button>
-      <input
-        placeholder="Buscar por cliente"
-        value={search}
-        onChange={e => setSearch(e.target.value)}
-      />
-      <ul className="list">
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <button onClick={() => setShow(true)} className="flex items-center gap-2 bg-blue-600 text-white px-3 py-2 rounded">
+          <img src={plus} alt="" className="w-5 h-5" />Nueva venta
+        </button>
+        <input
+          className="border rounded px-3 py-2"
+          placeholder="Buscar por cliente"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+      </div>
+      <ul className="grid gap-3">
         {filtered.map(s => (
-          <li key={`${s.clientId}-${s.id}`}>
+          <li key={`${s.clientId}-${s.id}`} className="bg-white p-4 rounded shadow">
             {s.clientName} - {new Date(s.date).toLocaleDateString()} - {s.description} - ${s.amount}
           </li>
         ))}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sistema de Ventas a Crédito</title>
+    <script src="https://cdn.tailwindcss.com"></script>
     <script type="module" crossorigin src="/assets/index-Dd7jR4op.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D0i6oLS8.css">
   </head>


### PR DESCRIPTION
## Summary
- integrate Tailwind via CDN and redesign layout
- add sidebar/topbar structure
- update forms and lists to use cards and modern styling
- polish modal and login screen

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68883c2f4fb0832591d621988f42d47a