### PR TITLE
Fix sidebar layout on mobile

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -59,7 +59,7 @@ function MainContent({ page, setPage }) {
           onClick={() => setOpen(false)}
         />
       )}
-      <aside className={`bg-slate-800 text-white w-60 p-4 space-y-2 fixed inset-y-0 left-0 transform ${open ? 'translate-x-0' : '-translate-x-full'} transition-transform md:relative md:translate-x-0 z-20 relative`}>
+      <aside className={`bg-slate-800 text-white w-60 p-4 space-y-2 fixed inset-y-0 left-0 transform ${open ? 'translate-x-0' : '-translate-x-full'} transition-transform md:relative md:translate-x-0 z-20`}>
         <button
           className="md:hidden absolute top-2 right-2 text-2xl"
           onClick={() => setOpen(false)}


### PR DESCRIPTION
## Summary
- remove leftover `relative` class so the sidebar does not occupy space when hidden

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68893ab789e8832594d28ae4cea845c5