### PR TITLE
Update menu layout and header

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,9 +5,6 @@ import Report from './components/Report'
 import SalesList from './components/SalesList'
 import { AuthProvider, useAuth } from './AuthProvider'
 import Login from './Login'
-import cart from './assets/icons/cart.svg'
-import users from './assets/icons/users.svg'
-import dollar from './assets/icons/dollar.svg'
 import './App.css'
 
 function MainContent({ page, setPage }) {
@@ -66,17 +63,27 @@ function MainContent({ page, setPage }) {
         >
           ×
         </button>
-        <img src="/assets/logo.png" alt="Claus Vende" className="h-10 mx-auto mb-4" />
         <h1 className="text-lg font-semibold mb-4 text-center">Menú</h1>
         <nav className="flex flex-col gap-2">
-          <button onClick={() => go('sales')} className="flex items-center gap-2 px-3 py-2 rounded hover:bg-blue-500 text-left">
-            <img src={cart} alt="" className="w-5 h-5" />Ventas
+          <button onClick={() => go('sales')} className="flex items-center gap-2 px-3 py-2 rounded hover:bg-blue-500 text-left group">
+            <svg className="w-5 h-5 text-current group-hover:text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M2.25 2.25a.75.75 0 000 1.5h1.386c.17 0 .318.114.362.278l2.558 9.592a3.752 3.752 0 00-2.806 3.63c0 .414.336.75.75.75h15.75a.75.75 0 000-1.5H5.378A2.25 2.25 0 017.5 15h11.218a.75.75 0 00.674-.421 60.358 60.358 0 002.96-7.228.75.75 0 00-.525-.965A60.864 60.864 0 005.68 4.509l-.232-.867A1.875 1.875 0 003.636 2.25H2.25zM3.75 20.25a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zM16.5 20.25a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z"/>
+            </svg>
+            Ventas
           </button>
-          <button onClick={() => go('clients')} className="flex items-center gap-2 px-3 py-2 rounded hover:bg-blue-500 text-left">
-            <img src={users} alt="" className="w-5 h-5" />Clientes
+          <button onClick={() => go('clients')} className="flex items-center gap-2 px-3 py-2 rounded hover:bg-blue-500 text-left group">
+            <svg className="w-5 h-5 text-current group-hover:text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M8.25 6.75a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0zM15.75 9.75a3 3 0 116 0 3 3 0 01-6 0zM2.25 9.75a3 3 0 116 0 3 3 0 01-6 0zM6.31 15.117A6.745 6.745 0 0112 12a6.745 6.745 0 016.709 7.498.75.75 0 01-.372.568A12.696 12.696 0 0112 21.75c-2.305 0-4.47-.612-6.337-1.684a.75.75 0 01-.372-.568 6.787 6.787 0 011.019-4.38z" clip-rule="evenodd"/>
+              <path d="M5.082 14.254a8.287 8.287 0 00-1.308 5.135 9.687 9.687 0 01-1.764-.44l-.115-.04a.563.563 0 01-.373-.487l-.01-.121a3.75 3.75 0 013.57-4.047zM20.226 19.389a8.287 8.287 0 00-1.308-5.135 3.75 3.75 0 013.57 4.047l-.01.121a.563.563 0 01-.373.486l-.115.04c-.567.2-1.156.349-1.764.441z"/>
+            </svg>
+            Clientes
           </button>
-          <button onClick={() => go('finance')} className="flex items-center gap-2 px-3 py-2 rounded hover:bg-blue-500 text-left">
-            <img src={dollar} alt="" className="w-5 h-5" />Finanzas
+          <button onClick={() => go('finance')} className="flex items-center gap-2 px-3 py-2 rounded hover:bg-blue-500 text-left group">
+            <svg className="w-5 h-5 text-current group-hover:text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M10.464 8.746c.227-.18.497-.311.786-.394v2.795a2.252 2.252 0 01-.786-.393c-.394-.313-.546-.681-.546-1.004 0-.323.152-.691.546-1.004zM12.75 15.662v-2.824c.347.085.664.228.921.421.427.32.579.686.579.991 0 .305-.152.671-.579.991a2.534 2.534 0 01-.921.42z"/>
+              <path fill-rule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zM12.75 6a.75.75 0 00-1.5 0v.816a3.836 3.836 0 00-1.72.756c-.712.566-1.112 1.35-1.112 2.178 0 .829.4 1.612 1.113 2.178.502.4 1.102.647 1.719.756v2.978a2.536 2.536 0 01-.921-.421l-.879-.66a.75.75 0 00-.9 1.2l.879.66c.533.4 1.169.645 1.821.75V18a.75.75 0 001.5 0v-.81a4.124 4.124 0 001.821-.749c.745-.559 1.179-1.344 1.179-2.191 0-.847-.434-1.632-1.179-2.191a4.122 4.122 0 00-1.821-.75V8.354c.29.082.559.213.786.393l.415.33a.75.75 0 00.933-1.175l-.415-.33a3.836 3.836 0 00-1.719-.755V6z" clip-rule="evenodd"/>
+            </svg>
+            Finanzas
           </button>
         </nav>
       </aside>
@@ -89,17 +96,17 @@ function MainContent({ page, setPage }) {
             >
               ☰
             </button>
-            <img src="/assets/logo.png" alt="Claus Vende" className="h-8" />
-          </div>
-          <div className="flex items-center gap-2">
-            <img src={user.photoURL} alt="avatar" className="w-8 h-8 rounded-full" />
-            <div className="leading-tight">
-              <p className="font-semibold leading-tight md:hidden">{nombres}</p>
-              <p className="font-semibold leading-tight md:hidden">{apellidos}</p>
-              <p className="font-semibold leading-none hidden md:block">{user.displayName}</p>
-              <p className="text-xs text-gray-700">{role}</p>
+            <div className="flex items-center gap-2">
+              <img src={user.photoURL} alt="avatar" className="w-8 h-8 rounded-full" />
+              <div className="leading-tight">
+                <p className="font-semibold leading-tight md:hidden">{nombres}</p>
+                <p className="font-semibold leading-tight md:hidden">{apellidos}</p>
+                <p className="font-semibold leading-none hidden md:block">{user.displayName}</p>
+                <p className="text-xs text-gray-700">{role}</p>
+              </div>
             </div>
           </div>
+          <img src="/assets/logo.png" alt="Claus Vende" className="h-8" />
           <button onClick={logout} className="bg-red-500 text-white px-3 py-1 rounded">Cerrar sesión</button>
         </header>
         <main className="p-4 mt-20 md:mt-16 flex-1">{content}</main>


### PR DESCRIPTION
## Summary
- remove sidebar logo
- swap logo and user info in header
- color menu icons the same as text and add hover effect

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a5f22e6208325acb0e71199e2cd6a