### PR TITLE
Improve card design

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -131,7 +131,7 @@ form {
 
 .actions {
   display: flex;
-  gap: 0.25rem;
+  gap: 0.5rem;
   align-items: center;
 }
 
@@ -145,4 +145,23 @@ form {
   color: inherit;
   display: flex;
   align-items: center;
+}
+
+/* Generic card style for list items */
+.card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media (min-width: 640px) {
+  .card {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
 }

--- a/frontend/src/components/ClientDetails.jsx
+++ b/frontend/src/components/ClientDetails.jsx
@@ -146,7 +146,7 @@ export default function ClientDetails({ id, go }) {
       <h3 className="font-semibold">Ventas</h3>
       <ul className="grid gap-2">
         {sales.map(s => (
-          <li key={s.id} className="bg-white p-2 rounded shadow">
+          <li key={s.id} className="card p-2">
             {editingSaleId === s.id ? (
               <>
                 <input
@@ -168,10 +168,10 @@ export default function ClientDetails({ id, go }) {
             ) : (
               <>
                 {new Date(s.date).toLocaleDateString()} - {s.description} - ${s.amount}
-                <button onClick={() => startEditSale(s)}>
+                <button onClick={() => startEditSale(s)} title="Editar">
                   <img src={editIcon} alt="editar" className="icon" />
                 </button>
-                <button onClick={() => removeSale(s)}>
+                <button onClick={() => removeSale(s)} title="Eliminar">
                   <img src={trash} alt="eliminar" className="icon" />
                 </button>
               </>
@@ -182,7 +182,7 @@ export default function ClientDetails({ id, go }) {
       <h3 className="font-semibold">Abonos</h3>
       <ul className="grid gap-2">
         {payments.map(p => (
-          <li key={p.id} className="bg-white p-2 rounded shadow">
+          <li key={p.id} className="card p-2">
             {editingId === p.id ? (
               <>
                 <input
@@ -204,10 +204,10 @@ export default function ClientDetails({ id, go }) {
             ) : (
               <>
                 {new Date(p.date).toLocaleDateString()} - ${p.amount}
-                <button onClick={() => startEdit(p)}>
+                <button onClick={() => startEdit(p)} title="Editar">
                   <img src={editIcon} alt="editar" className="icon" />
                 </button>
-                <button onClick={() => removePayment(p)}>
+                <button onClick={() => removePayment(p)} title="Eliminar">
                   <img src={trash} alt="eliminar" className="icon" />
                 </button>
               </>

--- a/frontend/src/components/ClientList.jsx
+++ b/frontend/src/components/ClientList.jsx
@@ -69,33 +69,30 @@ export default function ClientList({ go }) {
         {filtered.map(c => {
           const cleanPhone = (c.phone || '').replace(/\D/g, '');
           return (
-            <li
-              key={c.id}
-              className="bg-white p-4 rounded shadow flex flex-col sm:flex-row sm:items-center justify-between gap-2 border-l-4 border-blue-500"
-            >
+            <li key={c.id} className="card border-l-4 border-blue-500">
               <div className="flex-1">
-                <p className="font-medium">{c.name}</p>
+                <p className="font-semibold">{c.name}</p>
                 <p className="text-sm text-gray-800">Deuda: ${c.balance || 0}</p>
               </div>
-              <span className="flex gap-1">
-                <button onClick={() => go('client', c.id)}>
+              <span className="actions">
+                <button onClick={() => go('client', c.id)} title="Ver">
                   <img src={eye} alt="ver" className="icon" />
                 </button>
-                <button onClick={() => setStatementId(c.id)}>
+                <button onClick={() => setStatementId(c.id)} title="Estado">
                   <img src={docIcon} alt="estado" className="icon" />
                 </button>
-                <button onClick={() => setPayClientId(c.id)}>
+                <button onClick={() => setPayClientId(c.id)} title="Abono">
                   <img src={dollar} alt="abono" className="icon" />
                 </button>
                 {cleanPhone && (
-                  <a href={`https://wa.me/${cleanPhone}`} target="_blank" rel="noopener noreferrer">
+                  <a href={`https://wa.me/${cleanPhone}`} target="_blank" rel="noopener noreferrer" title="Mensaje">
                     <img src={chat} alt="mensaje" className="icon" />
                   </a>
                 )}
-                <button onClick={() => setEditClient(c)}>
+                <button onClick={() => setEditClient(c)} title="Editar">
                   <img src={editIcon} alt="editar" className="icon" />
                 </button>
-                <button onClick={() => removeClient(c)}>
+                <button onClick={() => removeClient(c)} title="Eliminar">
                   <img src={trash} alt="eliminar" className="icon" />
                 </button>
               </span>

--- a/frontend/src/components/Report.jsx
+++ b/frontend/src/components/Report.jsx
@@ -266,14 +266,14 @@ export default function Report() {
             {debtors.map(d => {
               const cleanPhone = (d.phone || '').replace(/\D/g, '')
               return (
-                <li key={d.id} className="bg-white p-4 rounded shadow flex justify-between items-center border-l-4 border-red-500">
-                  <span className="font-medium">{`${d.name} - $${d.balance}`}</span>
-                  <span className="flex gap-1">
-                    <button onClick={() => setPayClientId(d.id)}>
+                <li key={d.id} className="card border-l-4 border-red-500">
+                  <span className="font-semibold">{`${d.name} - $${d.balance}`}</span>
+                  <span className="actions">
+                    <button onClick={() => setPayClientId(d.id)} title="Abono">
                       <img src={dollar} alt="abono" className="icon" />
                     </button>
                     {cleanPhone && (
-                      <a href={`https://wa.me/${cleanPhone}`} target="_blank" rel="noopener noreferrer">
+                      <a href={`https://wa.me/${cleanPhone}`} target="_blank" rel="noopener noreferrer" title="Mensaje">
                         <img src={chat} alt="mensaje" className="icon" />
                       </a>
                     )}

--- a/frontend/src/components/SalesList.jsx
+++ b/frontend/src/components/SalesList.jsx
@@ -79,19 +79,19 @@ export default function SalesList() {
         {filtered.map(s => (
           <li
             key={`${s.clientId}-${s.id}`}
-            className="bg-white p-4 rounded shadow flex flex-col sm:flex-row sm:items-center justify-between gap-2 border-l-4 border-blue-500"
+            className="card border-l-4 border-blue-500"
           >
             <div className="flex-1">
-              <p className="font-medium">{s.clientName}</p>
+              <p className="font-semibold">{s.clientName}</p>
               <p className="text-sm text-gray-800">
                 {new Date(s.date).toLocaleDateString()} - {s.description} - ${s.amount}
               </p>
             </div>
-            <span className="flex gap-1">
-              <button onClick={() => setEditSale(s)}>
+            <span className="actions">
+              <button onClick={() => setEditSale(s)} title="Editar">
                 <img src={editIcon} alt="editar" className="icon" />
               </button>
-              <button onClick={() => removeSale(s)}>
+              <button onClick={() => removeSale(s)} title="Eliminar">
                 <img src={trash} alt="eliminar" className="icon" />
               </button>
             </span>


### PR DESCRIPTION
## Summary
- add generic card styles
- restyle sales, client, and debtor cards
- tweak actions spacing
- add tooltips to action icons

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688ac446e38c8325a7b017065f243e18