### PR TITLE
Apply thousand separators to monetary values

### DIFF
--- a/frontend/src/components/AccountStatement.jsx
+++ b/frontend/src/components/AccountStatement.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useRef } from 'react';
 import { db } from '../firebase';
 import jsPDF from 'jspdf';
 import html2canvas from 'html2canvas';
+import { formatMoney } from '../utils';
 
 export default function AccountStatement({ clientId }) {
   const [client, setClient] = useState(null);
@@ -46,21 +47,21 @@ export default function AccountStatement({ clientId }) {
         <p><strong>Nombre:</strong> {client.name}</p>
         <p><strong>Teléfono:</strong> {client.phone}</p>
         {client.notes && <p><strong>Notas:</strong> {client.notes}</p>}
-        <p><strong>Saldo actual:</strong> ${client.balance || 0}</p>
+        <p><strong>Saldo actual:</strong> ${formatMoney(client.balance)}</p>
         <h3 className="font-semibold">Ventas</h3>
         <ul className="list-disc pl-5">
           {sales.map(s => (
-            <li key={s.id}>{new Date(s.date).toLocaleDateString()} - {s.description} - ${s.amount}</li>
+            <li key={s.id}>{new Date(s.date).toLocaleDateString()} - {s.description} - ${formatMoney(s.amount)}</li>
           ))}
         </ul>
         <h3 className="font-semibold">Abonos</h3>
         <ul className="list-disc pl-5">
           {payments.map(p => (
-            <li key={p.id}>{new Date(p.date).toLocaleDateString()} - ${p.amount}</li>
+            <li key={p.id}>{new Date(p.date).toLocaleDateString()} - ${formatMoney(p.amount)}</li>
           ))}
         </ul>
-        <p><strong>Total compras:</strong> ${totalSales}</p>
-        <p><strong>Total abonos:</strong> ${totalPayments}</p>
+        <p><strong>Total compras:</strong> ${formatMoney(totalSales)}</p>
+        <p><strong>Total abonos:</strong> ${formatMoney(totalPayments)}</p>
       </div>
       <button onClick={exportPdf} className="bg-blue-500 text-white px-3 py-2 rounded">Generar PDF</button>
     </div>

--- a/frontend/src/components/AddSale.jsx
+++ b/frontend/src/components/AddSale.jsx
@@ -2,6 +2,7 @@ import { collection, getDocs, doc, addDoc, updateDoc, increment } from 'firebase
 import { useEffect, useState } from 'react';
 import jsPDF from 'jspdf';
 import { db } from '../firebase';
+import { formatMoney } from '../utils';
 
 export default function AddSale({ go, onDone, sale }) {
   const [clients, setClients] = useState([]);
@@ -58,7 +59,7 @@ export default function AddSale({ go, onDone, sale }) {
         pdf.text(`Cliente: ${client.name}`, 5, 20);
         pdf.text(`Fecha: ${new Date(ts).toLocaleString()}`, 5, 30);
         pdf.text(desc, 5, 40);
-        pdf.text(`Monto: $${value.toFixed(2)}`, 5, 50);
+        pdf.text(`Monto: $${formatMoney(value)}`, 5, 50);
         pdf.save('ticket.pdf');
       }
     }

--- a/frontend/src/components/ClientDetails.jsx
+++ b/frontend/src/components/ClientDetails.jsx
@@ -5,6 +5,7 @@ import AddClient from './AddClient';
 import Modal from './Modal';
 import editIcon from '../assets/icons/edit.svg';
 import trash from '../assets/icons/trash.svg';
+import { formatMoney } from '../utils';
 
 export default function ClientDetails({ id, go }) {
   const [client, setClient] = useState(null);
@@ -138,7 +139,7 @@ export default function ClientDetails({ id, go }) {
       {client.notes && (
         <p className="text-gray-800">Observaciones: {client.notes}</p>
       )}
-      <p className="text-gray-800">Deuda actual: ${client.balance || 0}</p>
+      <p className="text-gray-800">Deuda actual: ${formatMoney(client.balance)}</p>
       <form onSubmit={addPayment} className="flex gap-2">
         <input className="border rounded px-3 py-2 flex-1" value={amount} onChange={e => setAmount(e.target.value)} placeholder="Monto del abono" type="number" step="0.01" />
         <button type="submit" className="bg-blue-500 text-white px-3 py-2 rounded">Registrar abono</button>
@@ -167,7 +168,7 @@ export default function ClientDetails({ id, go }) {
               </>
             ) : (
               <>
-                {new Date(s.date).toLocaleDateString()} - {s.description} - ${s.amount}
+                {new Date(s.date).toLocaleDateString()} - {s.description} - ${formatMoney(s.amount)}
                 <button onClick={() => startEditSale(s)} title="Editar">
                   <img src={editIcon} alt="editar" className="icon" />
                 </button>
@@ -203,7 +204,7 @@ export default function ClientDetails({ id, go }) {
               </>
             ) : (
               <>
-                {new Date(p.date).toLocaleDateString()} - ${p.amount}
+                {new Date(p.date).toLocaleDateString()} - ${formatMoney(p.amount)}
                 <button onClick={() => startEdit(p)} title="Editar">
                   <img src={editIcon} alt="editar" className="icon" />
                 </button>

--- a/frontend/src/components/Report.jsx
+++ b/frontend/src/components/Report.jsx
@@ -7,6 +7,7 @@ import users from '../assets/icons/users.svg'
 import Modal from './Modal'
 import AddPayment from './AddPayment'
 import { db } from '../firebase'
+import { formatMoney } from '../utils'
 
 export default function Report() {
   const [metrics, setMetrics] = useState({
@@ -180,21 +181,21 @@ export default function Report() {
           <img src={dollar} alt="" className="w-6 h-6 text-blue-600" />
           <div>
             <p className="text-sm text-gray-600">Saldo por cobrar</p>
-              <p className="text-lg font-bold">{`$${metrics.outstanding.toFixed(2)}`}</p>
+              <p className="text-lg font-bold">{`$${formatMoney(metrics.outstanding)}`}</p>
           </div>
         </div>
         <div className="bg-white p-4 rounded shadow flex items-center gap-3">
           <img src={dollar} alt="" className="w-6 h-6 text-green-600" />
           <div>
             <p className="text-sm text-gray-600">Abonos del mes</p>
-              <p className="text-lg font-bold">{`$${metrics.monthlyPayments.toFixed(2)}`}</p>
+              <p className="text-lg font-bold">{`$${formatMoney(metrics.monthlyPayments)}`}</p>
           </div>
         </div>
         <div className="bg-white p-4 rounded shadow flex items-center gap-3">
           <img src={cart} alt="" className="w-6 h-6 text-blue-600" />
           <div>
             <p className="text-sm text-gray-600">Total ventas a crédito</p>
-              <p className="text-lg font-bold">{`$${metrics.totalSales.toFixed(2)}`}</p>
+              <p className="text-lg font-bold">{`$${formatMoney(metrics.totalSales)}`}</p>
           </div>
         </div>
         <div className="bg-white p-4 rounded shadow flex items-center gap-3">
@@ -220,7 +221,7 @@ export default function Report() {
             <img src={users} alt="" className="w-6 h-6 text-red-600" />
             <div>
               <p className="text-sm text-gray-600">Mayor saldo</p>
-              <p className="text-lg font-bold">{`${metrics.topDebtor.name} - $${metrics.topDebtor.balance.toFixed(2)}`}</p>
+              <p className="text-lg font-bold">{`${metrics.topDebtor.name} - $${formatMoney(metrics.topDebtor.balance)}`}</p>
             </div>
           </div>
         )}
@@ -234,7 +235,7 @@ export default function Report() {
               <div className="bg-green-500" style={{ width: `${(metrics.dueBalance / (metrics.dueBalance + metrics.overdueBalance || 1)) * 100}%` }} />
               <div className="bg-red-500" style={{ width: `${(metrics.overdueBalance / (metrics.dueBalance + metrics.overdueBalance || 1)) * 100}%` }} />
             </div>
-              <span className="text-sm">{`$${metrics.dueBalance.toFixed(2)} / $${metrics.overdueBalance.toFixed(2)}`}</span>
+              <span className="text-sm">{`$${formatMoney(metrics.dueBalance)} / $${formatMoney(metrics.overdueBalance)}`}</span>
           </div>
         </div>
         <div className="bg-white p-4 rounded shadow">

--- a/frontend/src/components/SalesList.jsx
+++ b/frontend/src/components/SalesList.jsx
@@ -6,6 +6,7 @@ import Modal from './Modal';
 import plus from '../assets/icons/plus.svg';
 import editIcon from '../assets/icons/edit.svg';
 import trash from '../assets/icons/trash.svg';
+import { formatMoney } from '../utils';
 
 export default function SalesList() {
   const [sales, setSales] = useState([]);
@@ -84,7 +85,7 @@ export default function SalesList() {
             <div className="flex-1">
               <p className="font-semibold">{s.clientName}</p>
               <p className="text-sm text-gray-800">
-                {new Date(s.date).toLocaleDateString()} - {s.description} - ${s.amount}
+                {new Date(s.date).toLocaleDateString()} - {s.description} - ${formatMoney(s.amount)}
               </p>
             </div>
             <span className="actions">

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,0 +1,6 @@
+export function formatMoney(value) {
+  return Number(value || 0).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+}


### PR DESCRIPTION
## Summary
- add `formatMoney` helper and use it across components
- display balances, sales and payments with thousands separators

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688ace29d858832598f68b0b1d8dcb79