### PR TITLE
Improve search with debounce

### DIFF
--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,6 +1,21 @@
+import { useState, useEffect } from 'react';
+
 export function formatMoney(value) {
   return Number(value || 0).toLocaleString('en-US', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2
   });
+}
+
+// Delay value updates until the user stops typing for the given delay
+// Useful to avoid firing search queries on every key press
+export function useDebounce(value, delay = 400) {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
 }


### PR DESCRIPTION
## Summary
- add generic `useDebounce` hook
- update client and sales lists to wait 400ms before filtering
- show friendly message when no results found

## Testing
- `npm install`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ad1c2abdc83259d738d363d46a05e