### PR TITLE
Fix jsPDF.text error

### DIFF
--- a/frontend/src/components/AccountStatement.jsx
+++ b/frontend/src/components/AccountStatement.jsx
@@ -43,11 +43,11 @@ export default function AccountStatement({ clientId }) {
     y += 6;
 
     pdf.setFontSize(10);
-    pdf.text(`Nombre: ${client.name}`, margin, y);
+    pdf.text(String(`Nombre: ${client.name}`), margin, y);
     y += 4;
-    pdf.text(`Teléfono: ${client.phone}`, margin, y);
+    pdf.text(String(`Teléfono: ${client.phone}`), margin, y);
     y += 4;
-    pdf.text(`Fecha: ${new Date().toLocaleDateString()}`, margin, y);
+    pdf.text(String(`Fecha: ${new Date().toLocaleDateString()}`), margin, y);
     y += 6;
 
     pdf.setFontSize(12);
@@ -61,8 +61,8 @@ export default function AccountStatement({ clientId }) {
     ];
     pdf.setFont(undefined, 'bold');
     resumen.forEach(r => {
-      pdf.text(r[0], margin, y);
-      pdf.text(`$${r[1]}`, pageWidth - margin, y, { align: 'right' });
+      pdf.text(String(r[0]), margin, y);
+      pdf.text(String(`$${r[1]}`), pageWidth - margin, y, { align: 'right' });
       y += 4;
     });
     pdf.setFont(undefined, 'normal');
@@ -87,11 +87,11 @@ export default function AccountStatement({ clientId }) {
     sales
       .sort((a, b) => a.date - b.date)
       .forEach(s => {
-        pdf.text(new Date(s.date).toLocaleDateString(), col[0], y);
-        pdf.text(s.description, col[1], y);
-        pdf.text(formatMoney(s.amount), col[2], y, { align: 'right' });
-        pdf.text(formatMoney(s.abonado), col[3], y, { align: 'right' });
-        pdf.text(s.pagada ? '✔' : formatMoney(s.pendiente), col[4], y, { align: 'right' });
+        pdf.text(String(new Date(s.date).toLocaleDateString()), col[0], y);
+        pdf.text(String(s.description), col[1], y);
+        pdf.text(String(formatMoney(s.amount)), col[2], y, { align: 'right' });
+        pdf.text(String(formatMoney(s.abonado)), col[3], y, { align: 'right' });
+        pdf.text(String(s.pagada ? '✔' : formatMoney(s.pendiente)), col[4], y, { align: 'right' });
         y += 4;
         if (y > pageHeight - margin) {
           pdf.addPage();
@@ -117,9 +117,9 @@ export default function AccountStatement({ clientId }) {
     payments
       .sort((a, b) => a.date - b.date)
       .forEach(p => {
-        pdf.text(new Date(p.date).toLocaleDateString(), pcol[0], y);
-        if (p.saleDescription) pdf.text(p.saleDescription, pcol[1], y);
-        pdf.text(formatMoney(p.amount), pcol[2], y, { align: 'right' });
+        pdf.text(String(new Date(p.date).toLocaleDateString()), pcol[0], y);
+        if (p.saleDescription) pdf.text(String(p.saleDescription), pcol[1], y);
+        pdf.text(String(formatMoney(p.amount)), pcol[2], y, { align: 'right' });
         y += 4;
         if (y > pageHeight - margin) {
           pdf.addPage();

--- a/frontend/src/components/AddSale.jsx
+++ b/frontend/src/components/AddSale.jsx
@@ -65,8 +65,8 @@ export default function AddSale({ go, onDone, sale }) {
         // Datos del cliente
         pdf.setFont('helvetica', 'normal');
         pdf.setFontSize(10);
-        pdf.text(`Cliente: ${client.name}`, 5, 17);
-        pdf.text(`Fecha: ${new Date(ts).toLocaleString()}`, 5, 23);
+        pdf.text(String(`Cliente: ${client.name}`), 5, 17);
+        pdf.text(String(`Fecha: ${new Date(ts).toLocaleString()}`), 5, 23);
         pdf.line(5, 26, 53, 26);
 
         // Detalle de la venta
@@ -74,15 +74,15 @@ export default function AddSale({ go, onDone, sale }) {
         pdf.text('Descripción', 5, 32);
         pdf.text('Monto', 53, 32, { align: 'right' });
         pdf.setFont('helvetica', 'normal');
-        pdf.text(desc, 5, 38);
-        pdf.text(`$${formatMoney(value)}`, 53, 38, { align: 'right' });
+        pdf.text(String(desc), 5, 38);
+        pdf.text(String(`$${formatMoney(value)}`), 53, 38, { align: 'right' });
         pdf.line(5, 44, 53, 44);
 
         // Total
         pdf.setFont('helvetica', 'bold');
         pdf.text('TOTAL:', 40, 50, { align: 'right' });
         pdf.setFontSize(14);
-        pdf.text(`$${formatMoney(value)}`, 53, 50, { align: 'right' });
+        pdf.text(String(`$${formatMoney(value)}`), 53, 50, { align: 'right' });
 
         // Pie de página
         pdf.setFont('helvetica', 'normal');


### PR DESCRIPTION
## Summary
- cast all jsPDF text inputs to strings to avoid invalid arguments

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688ae2b7528c83258c4763473f4f7226