### PR TITLE
Display last payment date for overdue clients

### DIFF
--- a/frontend/src/components/Report.jsx
+++ b/frontend/src/components/Report.jsx
@@ -70,7 +70,7 @@ export default function Report() {
         if (!lastPayment && sales.length) lastPayment = sales[sales.length - 1].date
         if (now - lastPayment >= monthMs) {
           overdueBalance += balance
-          overdueClients.push({ id: clientId, name, phone: data.phone, balance })
+          overdueClients.push({ id: clientId, name, phone: data.phone, balance, lastPayment })
         } else {
           dueBalance += balance
         }
@@ -263,7 +263,10 @@ export default function Report() {
               const cleanPhone = (d.phone || '').replace(/\D/g, '')
               return (
                 <li key={d.id} className="card border-l-4 border-red-500">
-                  <span className="font-semibold">{`${d.name} - $${formatMoney(d.balance)}`}</span>
+                  <div className="flex-1">
+                    <p className="font-semibold">{`${d.name} - $${formatMoney(d.balance)}`}</p>
+                    <p className="text-sm text-gray-700">Último abono: {new Date(d.lastPayment).toLocaleDateString()}</p>
+                  </div>
                   <span className="actions">
                     <button onClick={() => setPayClientId(d.id)} title="Abono">
                       <img src={dollar} alt="abono" className="icon" />


### PR DESCRIPTION
## Summary
- show last payment date when adding delinquent clients in the report

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b964a86708325877e53113d1a8b19