### PR TITLE
Restrict edit/delete for Vendedor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ La aplicación maneja permisos mediante un campo `role` guardado en la colecció
 
 Los permisos se definen así:
 
-- **Vendedor**: sólo puede acceder a las secciones de *Ventas* y *Clientes* y utilizar las funciones relacionadas.
+- **Vendedor**: sólo puede acceder a las secciones de *Ventas* y *Clientes* y utilizar las funciones relacionadas, pero **no** puede editar ni eliminar registros de clientes ni de ventas.
 - **Administrador**: tiene acceso completo al sitio, incluido el panel de *Finanzas*.
 
 ## Licencia

--- a/frontend/src/components/ClientDetails.jsx
+++ b/frontend/src/components/ClientDetails.jsx
@@ -1,5 +1,6 @@
 import { collection, addDoc, onSnapshot, doc, updateDoc, increment, deleteDoc } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
+import { useAuth } from '../AuthProvider';
 import { db } from '../firebase';
 import AddClient from './AddClient';
 import Modal from './Modal';
@@ -19,6 +20,7 @@ export default function ClientDetails({ id, go }) {
   const [editingSaleId, setEditingSaleId] = useState(null);
   const [editSaleAmount, setEditSaleAmount] = useState('');
   const [editSaleDate, setEditSaleDate] = useState('');
+  const { role } = useAuth();
 
   useEffect(() => {
     const unsubClient = onSnapshot(doc(db, 'clients', id), snap => {
@@ -146,12 +148,16 @@ export default function ClientDetails({ id, go }) {
       </button>
       <h2 className="text-lg font-semibold flex items-center gap-2">
         {client.name}
-        <button onClick={() => setEditMode(true)}>
-          <img src={editIcon} alt="editar" className="icon" />
-        </button>
-        <button onClick={removeClient}>
-          <img src={trash} alt="eliminar" className="icon" />
-        </button>
+        {role === 'Administrador' && (
+          <>
+            <button onClick={() => setEditMode(true)}>
+              <img src={editIcon} alt="editar" className="icon" />
+            </button>
+            <button onClick={removeClient}>
+              <img src={trash} alt="eliminar" className="icon" />
+            </button>
+          </>
+        )}
       </h2>
       <p className="text-gray-800">Teléfono: {client.phone}</p>
       {client.notes && (
@@ -167,7 +173,7 @@ export default function ClientDetails({ id, go }) {
         <ul className="grid gap-2">
           {salesData.map(s => (
             <li key={s.id} className="card">
-              {editingSaleId === s.id ? (
+              {role === 'Administrador' && editingSaleId === s.id ? (
                 <>
                   <input
                     className="border rounded px-2 py-1 mr-2"
@@ -194,12 +200,16 @@ export default function ClientDetails({ id, go }) {
                   </div>
                   <div className="flex items-center gap-2">
                     <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-1 rounded-full ${s.pagada ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'}`}>{s.pagada ? '✅ Pagada' : '⚠️ Pendiente'}</span>
-                    <button onClick={() => startEditSale(s)} title="Editar">
-                      <img src={editIcon} alt="editar" className="icon" />
-                    </button>
-                    <button onClick={() => removeSale(s)} title="Eliminar">
-                      <img src={trash} alt="eliminar" className="icon" />
-                    </button>
+                    {role === 'Administrador' && (
+                      <>
+                        <button onClick={() => startEditSale(s)} title="Editar">
+                          <img src={editIcon} alt="editar" className="icon" />
+                        </button>
+                        <button onClick={() => removeSale(s)} title="Eliminar">
+                          <img src={trash} alt="eliminar" className="icon" />
+                        </button>
+                      </>
+                    )}
                   </div>
                 </div>
               )}
@@ -251,7 +261,7 @@ export default function ClientDetails({ id, go }) {
           ))}
         </ul>
       </div>
-      {editMode && (
+      {role === 'Administrador' && editMode && (
         <Modal onClose={() => setEditMode(false)}>
           <AddClient client={client} onDone={() => setEditMode(false)} />
         </Modal>

--- a/frontend/src/components/ClientList.jsx
+++ b/frontend/src/components/ClientList.jsx
@@ -1,5 +1,6 @@
 import { collection, getDocs, deleteDoc, doc } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
+import { useAuth } from '../AuthProvider';
 import { db } from '../firebase';
 import AddClient from './AddClient';
 import Modal from './Modal';
@@ -21,6 +22,7 @@ export default function ClientList({ go }) {
   const [editClient, setEditClient] = useState(null);
   const [statementId, setStatementId] = useState(null);
   const [payClientId, setPayClientId] = useState(null);
+  const { role } = useAuth();
 
   const fetchClients = async () => {
     const snapshot = await getDocs(collection(db, 'clients'));
@@ -90,12 +92,16 @@ export default function ClientList({ go }) {
                     <img src={chat} alt="mensaje" className="icon" />
                   </a>
                 )}
-                <button onClick={() => setEditClient(c)} title="Editar">
-                  <img src={editIcon} alt="editar" className="icon" />
-                </button>
-                <button onClick={() => removeClient(c)} title="Eliminar">
-                  <img src={trash} alt="eliminar" className="icon" />
-                </button>
+                {role === 'Administrador' && (
+                  <>
+                    <button onClick={() => setEditClient(c)} title="Editar">
+                      <img src={editIcon} alt="editar" className="icon" />
+                    </button>
+                    <button onClick={() => removeClient(c)} title="Eliminar">
+                      <img src={trash} alt="eliminar" className="icon" />
+                    </button>
+                  </>
+                )}
               </span>
             </li>
           );

--- a/frontend/src/components/SalesList.jsx
+++ b/frontend/src/components/SalesList.jsx
@@ -1,5 +1,6 @@
 import { collection, getDocs, deleteDoc, doc, updateDoc, increment } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
+import { useAuth } from '../AuthProvider';
 import { db } from '../firebase';
 import AddSale from './AddSale';
 import Modal from './Modal';
@@ -13,6 +14,7 @@ export default function SalesList() {
   const [search, setSearch] = useState('');
   const [show, setShow] = useState(false);
   const [editSale, setEditSale] = useState(null);
+  const { role } = useAuth();
 
   const fetchSales = async () => {
     const clientSnap = await getDocs(collection(db, 'clients'));
@@ -89,12 +91,16 @@ export default function SalesList() {
               </p>
             </div>
             <span className="actions">
-              <button onClick={() => setEditSale(s)} title="Editar">
-                <img src={editIcon} alt="editar" className="icon" />
-              </button>
-              <button onClick={() => removeSale(s)} title="Eliminar">
-                <img src={trash} alt="eliminar" className="icon" />
-              </button>
+              {role === 'Administrador' && (
+                <>
+                  <button onClick={() => setEditSale(s)} title="Editar">
+                    <img src={editIcon} alt="editar" className="icon" />
+                  </button>
+                  <button onClick={() => removeSale(s)} title="Eliminar">
+                    <img src={trash} alt="eliminar" className="icon" />
+                  </button>
+                </>
+              )}
             </span>
           </li>
         ))}
@@ -104,7 +110,7 @@ export default function SalesList() {
           <AddSale onDone={() => { setShow(false); fetchSales(); }} />
         </Modal>
       )}
-      {editSale && (
+      {role === 'Administrador' && editSale && (
         <Modal onClose={() => setEditSale(null)}>
           <AddSale sale={editSale} onDone={() => { setEditSale(null); fetchSales(); }} />
         </Modal>


### PR DESCRIPTION
## Summary
- document that sellers cannot edit or delete clients or sales
- limit edit/delete buttons for non-admin users in ClientList, SalesList and ClientDetails

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688bc802b1748325b8ad555d4c01dca0