### PR TITLE
Improve user info display

### DIFF
--- a/frontend/src/AuthProvider.jsx
+++ b/frontend/src/AuthProvider.jsx
@@ -20,16 +20,24 @@ export function AuthProvider({ children }) {
           setRole(null)
           return
         }
-        setUser(u)
         const ref = doc(db, 'users', u.uid)
         const snap = await getDoc(ref)
+        let data
         if (snap.exists()) {
-          setRole(snap.data().role)
-          if (!snap.data().email) await setDoc(ref, { email: u.email, displayName: u.displayName }, { merge: true })
+          data = snap.data()
+          setRole(data.role)
+          if (!data.email) {
+            await setDoc(ref, { email: u.email, displayName: u.displayName, photoURL: u.photoURL }, { merge: true })
+            data.email = u.email
+            data.displayName = data.displayName || u.displayName
+            data.photoURL = u.photoURL
+          }
         } else {
-          await setDoc(ref, { role: 'Vendedor', email: u.email, displayName: u.displayName })
+          data = { role: 'Vendedor', email: u.email, displayName: u.displayName, photoURL: u.photoURL }
+          await setDoc(ref, data)
           setRole('Vendedor')
         }
+        setUser({ ...u, ...data, id: u.uid })
       } else {
         setUser(null)
         setRole(null)

--- a/frontend/src/components/UsersList.jsx
+++ b/frontend/src/components/UsersList.jsx
@@ -40,8 +40,16 @@ export default function UsersList() {
         <h3 className="text-lg font-semibold">Usuarios Registrados</h3>
         <ul className="grid gap-2">
           {users.map(u => (
-            <li key={u.id} className="card">
-              <span className="flex-1">{u.displayName || u.email || u.id}</span>
+            <li key={u.id} className="card sm:flex-row sm:items-center">
+              <img
+                src={u.photoURL || '/vite.svg'}
+                alt="avatar"
+                className="w-12 h-12 rounded-full"
+              />
+              <div className="flex-1">
+                <p className="font-semibold">{u.displayName || u.email || u.id}</p>
+                <p className="text-sm text-gray-600">{u.email}</p>
+              </div>
               <select
                 value={u.role}
                 onChange={e => changeRole(u.id, e.target.value)}


### PR DESCRIPTION
## Summary
- use Firestore profile data when creating the auth context
- display Gmail photo, name, email and role in user cards

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688be7fabe448325a6392860b9a0563a