### PR TITLE
Improve user management

### DIFF
--- a/frontend/src/components/AddUser.jsx
+++ b/frontend/src/components/AddUser.jsx
@@ -3,12 +3,18 @@ import { useState } from 'react'
 import { db } from '../firebase'
 
 export default function AddUser({ onDone }) {
+  const [name, setName] = useState('')
   const [email, setEmail] = useState('')
+  const [role, setRole] = useState('Vendedor')
 
   const handleSubmit = async e => {
     e.preventDefault()
     if (!email) return
-    await setDoc(doc(db, 'usuarios', email), { createdAt: Date.now() })
+    await setDoc(doc(db, 'usuarios', email), {
+      createdAt: Date.now(),
+      name,
+      role
+    })
     if (onDone) onDone()
   }
 
@@ -17,12 +23,27 @@ export default function AddUser({ onDone }) {
       <h2 className="text-lg font-semibold text-center">Nuevo Usuario</h2>
       <input
         className="w-full border rounded px-3 py-2"
+        value={name}
+        onChange={e => setName(e.target.value)}
+        placeholder="Nombre"
+        required
+      />
+      <input
+        className="w-full border rounded px-3 py-2"
         type="email"
         value={email}
         onChange={e => setEmail(e.target.value)}
         placeholder="Correo"
         required
       />
+      <select
+        className="w-full border rounded px-3 py-2"
+        value={role}
+        onChange={e => setRole(e.target.value)}
+      >
+        <option value="Vendedor">Vendedor</option>
+        <option value="Administrador">Administrador</option>
+      </select>
       <button type="submit" className="w-full bg-blue-500 text-white py-2 rounded">Guardar</button>
     </form>
   )

--- a/frontend/src/components/UsersList.jsx
+++ b/frontend/src/components/UsersList.jsx
@@ -26,10 +26,24 @@ export default function UsersList() {
     load()
   }
 
-  const changeRole = async (id, role) => {
-    await updateDoc(doc(db, 'users', id), { role })
+  const changeRole = async (userId, email, role) => {
+    if (userId) {
+      await updateDoc(doc(db, 'users', userId), { role })
+    }
+    await updateDoc(doc(db, 'usuarios', email), { role })
     load()
   }
+
+  const merged = allowed.map(a => {
+    const user = users.find(u => u.email === a.id)
+    return {
+      email: a.id,
+      name: user?.displayName || a.name,
+      photoURL: user?.photoURL,
+      role: user?.role || a.role || 'Vendedor',
+      userId: user?.id
+    }
+  })
 
   return (
     <div className="space-y-6">
@@ -39,39 +53,31 @@ export default function UsersList() {
       <div className="space-y-2">
         <h3 className="text-lg font-semibold">Usuarios Registrados</h3>
         <ul className="grid gap-2">
-          {users.map(u => (
-            <li key={u.id} className="card sm:flex-row sm:items-center">
+          {merged.map(u => (
+            <li key={u.email} className="card sm:flex-row sm:items-center">
               <img
                 src={u.photoURL || '/vite.svg'}
                 alt="avatar"
                 className="w-12 h-12 rounded-full"
               />
               <div className="flex-1">
-                <p className="font-semibold">{u.displayName || u.email || u.id}</p>
+                <p className="font-semibold">{u.name || u.email}</p>
                 <p className="text-sm text-gray-600">{u.email}</p>
               </div>
               <select
                 value={u.role}
-                onChange={e => changeRole(u.id, e.target.value)}
+                onChange={e => changeRole(u.userId, u.email, e.target.value)}
                 className="border rounded px-2 py-1"
               >
                 <option value="Vendedor">Vendedor</option>
                 <option value="Administrador">Administrador</option>
               </select>
-              <button onClick={() => setEditUser(u)} title="Editar nombre">
-                <img src={editIcon} alt="editar" className="icon" />
-              </button>
-            </li>
-          ))}
-        </ul>
-      </div>
-      <div className="space-y-2">
-        <h3 className="text-lg font-semibold">Correos Permitidos</h3>
-        <ul className="grid gap-2">
-          {allowed.map(a => (
-            <li key={a.id} className="card">
-              <span className="flex-1">{a.id}</span>
-              <button onClick={() => removeAllow(a.id)} className="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
+              {u.userId && (
+                <button onClick={() => setEditUser(users.find(us => us.id === u.userId))} title="Editar nombre">
+                  <img src={editIcon} alt="editar" className="icon" />
+                </button>
+              )}
+              <button onClick={() => removeAllow(u.email)} className="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- allow capturing name and role when adding a new user
- show allowed emails merged with registered users in a single list
- pull role and name from allowed list when creating user profile

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688beab84334832594ed5667a3f69807