### PR TITLE
Apply uppercase and phone formatting

### DIFF
--- a/frontend/src/components/AddClient.jsx
+++ b/frontend/src/components/AddClient.jsx
@@ -10,26 +10,22 @@ export default function AddClient({ go, onDone, client }) {
   useEffect(() => {
     if (client) {
       setName(client.name || '');
-      setPhone(client.phone || '');
+      setPhone((client.phone || '').replace(/\D/g, ''));
       setNotes(client.notes || '');
     }
   }, [client]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    const payload = {
+      name: name.toUpperCase(),
+      phone: phone ? `(${phone.slice(0, 3)}) ${phone.slice(3, 6)} ${phone.slice(6, 10)}` : '',
+      notes: notes.toUpperCase(),
+    };
     if (client) {
-      await updateDoc(doc(db, 'clients', client.id), {
-        name,
-        phone,
-        notes,
-      });
+      await updateDoc(doc(db, 'clients', client.id), payload);
     } else {
-      await addDoc(collection(db, 'clients'), {
-        name,
-        phone,
-        notes,
-        balance: 0,
-      });
+      await addDoc(collection(db, 'clients'), { ...payload, balance: 0 });
     }
     if (onDone) onDone();
     else go('list');
@@ -41,21 +37,21 @@ export default function AddClient({ go, onDone, client }) {
       <input
         className="w-full border rounded px-3 py-2"
         value={name}
-        onChange={e => setName(e.target.value)}
+        onChange={e => setName(e.target.value.toUpperCase())}
         placeholder="Nombre"
         required
       />
       <input
         className="w-full border rounded px-3 py-2"
         value={phone}
-        onChange={e => setPhone(e.target.value)}
+        onChange={e => setPhone(e.target.value.replace(/\D/g, '').slice(0, 10))}
         placeholder="Teléfono"
-        pattern="\(\d{3}\) \d{3} \d{4}"
+        pattern="\d{10}"
       />
       <input
         className="w-full border rounded px-3 py-2"
         value={notes}
-        onChange={e => setNotes(e.target.value)}
+        onChange={e => setNotes(e.target.value.toUpperCase())}
         placeholder="Observaciones"
       />
       <button type="submit" className="w-full bg-blue-500 text-white py-2 rounded">Guardar</button>

--- a/frontend/src/components/AddSale.jsx
+++ b/frontend/src/components/AddSale.jsx
@@ -8,7 +8,7 @@ export default function AddSale({ go, onDone, sale }) {
   const [clients, setClients] = useState([]);
   const [clientId, setClientId] = useState(sale?.clientId || '');
   const [amount, setAmount] = useState(sale?.amount || '');
-  const [desc, setDesc] = useState(sale?.description || '');
+  const [desc, setDesc] = useState((sale?.description || '').toUpperCase());
   const [date, setDate] = useState(() => {
     if (sale?.date) return new Date(sale.date).toISOString().split('T')[0];
     return new Date().toISOString().split('T')[0];
@@ -26,7 +26,7 @@ export default function AddSale({ go, onDone, sale }) {
     if (sale) {
       setClientId(sale.clientId);
       setAmount(sale.amount);
-      setDesc(sale.description);
+      setDesc(sale.description.toUpperCase());
       setDate(new Date(sale.date).toISOString().split('T')[0]);
     }
   }, [sale]);
@@ -40,7 +40,7 @@ export default function AddSale({ go, onDone, sale }) {
       const diff = value - sale.amount;
       await updateDoc(doc(ref, 'sales', sale.id), {
         amount: value,
-        description: desc,
+        description: desc.toUpperCase(),
         date: new Date(date).getTime()
       });
       if (diff !== 0) {
@@ -48,7 +48,7 @@ export default function AddSale({ go, onDone, sale }) {
       }
     } else {
       const ts = new Date(date).getTime();
-      await addDoc(collection(ref, 'sales'), { amount: value, description: desc, date: ts });
+      await addDoc(collection(ref, 'sales'), { amount: value, description: desc.toUpperCase(), date: ts });
       await updateDoc(ref, { balance: increment(value), total: increment(value) });
 
       const client = clients.find(c => c.id === clientId);
@@ -117,7 +117,7 @@ export default function AddSale({ go, onDone, sale }) {
       <input
         className="w-full border rounded px-3 py-2"
         value={desc}
-        onChange={e => setDesc(e.target.value)}
+        onChange={e => setDesc(e.target.value.toUpperCase())}
         placeholder="Descripción"
         required
       />


### PR DESCRIPTION
## Descripción
- ajusta el formulario de clientes para registrar nombre, teléfono y observaciones con el formato correcto
- asegura que la descripción de la venta se almacene en mayúsculas

## Tipo de cambio
- [ ] Corrección de bug
- [x] Nueva característica
- [ ] Mejora

## Checklist
- [x] El código sigue las guías de estilo
- [x] Se ejecutó `npm run lint` sin errores
- [ ] Se actualizaron las documentaciones necesarias

------
https://chatgpt.com/codex/tasks/task_e_688cfdc33b2c8325a702294ff63693e1