### PR TITLE
Fix timezone issue when saving dates

### DIFF
--- a/frontend/src/components/AddPayment.jsx
+++ b/frontend/src/components/AddPayment.jsx
@@ -1,6 +1,7 @@
 import { collection, addDoc, updateDoc, increment, doc } from 'firebase/firestore';
 import { useState } from 'react';
 import { db } from '../firebase';
+import { parseLocalDate } from '../utils';
 
 export default function AddPayment({ clientId, onDone }) {
   const [amount, setAmount] = useState('');
@@ -12,7 +13,7 @@ export default function AddPayment({ clientId, onDone }) {
     if (isNaN(value) || !date) return;
     await addDoc(collection(db, 'clients', clientId, 'payments'), {
       amount: value,
-      date: new Date(date).getTime(),
+      date: parseLocalDate(date),
     });
     await updateDoc(doc(db, 'clients', clientId), {
       balance: increment(-value),

--- a/frontend/src/components/AddSale.jsx
+++ b/frontend/src/components/AddSale.jsx
@@ -2,7 +2,7 @@ import { collection, getDocs, doc, addDoc, updateDoc, increment } from 'firebase
 import { useEffect, useState } from 'react';
 import jsPDF from 'jspdf';
 import { db } from '../firebase';
-import { formatMoney } from '../utils';
+import { formatMoney, parseLocalDate } from '../utils';
 
 export default function AddSale({ go, onDone, sale }) {
   const [clients, setClients] = useState([]);
@@ -41,13 +41,13 @@ export default function AddSale({ go, onDone, sale }) {
       await updateDoc(doc(ref, 'sales', sale.id), {
         amount: value,
         description: desc.toUpperCase(),
-        date: new Date(date).getTime()
+        date: parseLocalDate(date)
       });
       if (diff !== 0) {
         await updateDoc(ref, { balance: increment(diff), total: increment(diff) });
       }
     } else {
-      const ts = new Date(date).getTime();
+      const ts = parseLocalDate(date);
       await addDoc(collection(ref, 'sales'), { amount: value, description: desc.toUpperCase(), date: ts });
       await updateDoc(ref, { balance: increment(value), total: increment(value) });
 

--- a/frontend/src/components/ClientDetails.jsx
+++ b/frontend/src/components/ClientDetails.jsx
@@ -6,7 +6,7 @@ import AddClient from './AddClient';
 import Modal from './Modal';
 import editIcon from '../assets/icons/edit.svg';
 import trash from '../assets/icons/trash.svg';
-import { formatMoney, applyPaymentsToSales } from '../utils';
+import { formatMoney, applyPaymentsToSales, parseLocalDate } from '../utils';
 
 export default function ClientDetails({ id, go }) {
   const [client, setClient] = useState(null);
@@ -72,7 +72,7 @@ export default function ClientDetails({ id, go }) {
     if (isNaN(newValue) || !editDate) return;
     await updateDoc(doc(db, 'clients', id, 'payments', p.id), {
       amount: newValue,
-      date: new Date(editDate).getTime(),
+      date: parseLocalDate(editDate),
     });
     const diff = newValue - p.amount;
     if (diff !== 0) {
@@ -104,7 +104,7 @@ export default function ClientDetails({ id, go }) {
     if (isNaN(newValue) || !editSaleDate) return;
     await updateDoc(doc(db, 'clients', id, 'sales', s.id), {
       amount: newValue,
-      date: new Date(editSaleDate).getTime(),
+      date: parseLocalDate(editSaleDate),
     });
     const diff = newValue - s.amount;
     if (diff !== 0) {

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -5,6 +5,14 @@ export function formatMoney(value) {
   });
 }
 
+// Convierte una fecha en formato YYYY-MM-DD a la marca de tiempo local a
+// medianoche. Esto evita el desfase de zona horaria que ocurre al usar
+// `new Date(string)` directamente.
+export function parseLocalDate(dateStr) {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return new Date(y, m - 1, d).getTime();
+}
+
 // Aplica abonos a las ventas en orden cronológico, actualizando
 // los campos `abonado`, `pendiente` y `pagada` de cada venta.
 export function applyPaymentsToSales(sales, payments) {


### PR DESCRIPTION
## Summary
- prevent timezone shift by parsing local date input
- save payments and sales using the new helper

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688d152f84e0832585c8ecdfab821c03